### PR TITLE
Set loglevel to info for client.py

### DIFF
--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -39,6 +39,7 @@ from .http import ClientCookieJar, MultipartFormDataEncoder
 from .common import ClientDeprecationWarning
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 warnings.simplefilter('always', ClientDeprecationWarning)
 
 


### PR DESCRIPTION
Logging in client.py is very verbose, so setting to INFO by default
